### PR TITLE
blacklist src directory

### DIFF
--- a/lib/discourse_theme/uploader.rb
+++ b/lib/discourse_theme/uploader.rb
@@ -16,6 +16,7 @@ class DiscourseTheme::Uploader
 
     Dir.chdir(dir + "/../") do
       Find.find(File.basename(dir)) do |x|
+        Find.prune if File.basename(x) == "src"
         Find.prune if File.basename(x)[0] == ?.
         next if File.directory?(x)
 
@@ -58,7 +59,7 @@ class DiscourseTheme::Uploader
       }
     }
 
-    endpoint = 
+    endpoint =
       if @is_theme_creator
         "/user_themes/#{@theme_id}"
       else
@@ -89,7 +90,7 @@ class DiscourseTheme::Uploader
     filename = "#{Pathname.new(Dir.tmpdir).realpath}/bundle_#{SecureRandom.hex}.tar.gz"
     compress_dir(filename, @dir)
 
-    endpoint = 
+    endpoint =
       if @is_theme_creator
         "/user_themes/import.json"
       else


### PR DESCRIPTION
## Request
Suggesting a change to either blacklist or whitelist files/directories that are included in the Uploader. 

## Reason
I'm using yarn and node to include some styles from our organization's design system, as well as few other helpful utilities, and concatenating them into the sass files that Discourse consumes. It blows up on some of the node includes, which don't need to be included in the tar ball. 

## Solution
### Blacklist
The quickest solution for me was to exclude a src directory where I can keep all of those files and directories. 

### Whitelist
Another option would be to specifically list the files and directories that are watched and compiled. This would be safer and allow users have other files and directories of the choice without concern of errors. However, that could require more upkeep on the gem to keep it in sync with what Discourse allows in the theme.