### PR TITLE
Make watcher ignore irrelevant files

### DIFF
--- a/lib/discourse_theme.rb
+++ b/lib/discourse_theme.rb
@@ -13,14 +13,14 @@ require 'json'
 require 'yaml'
 require 'tty/prompt'
 
-require 'discourse_theme/version'
-require 'discourse_theme/config'
-require 'discourse_theme/cli'
-require 'discourse_theme/client'
-require 'discourse_theme/downloader'
-require 'discourse_theme/uploader'
-require 'discourse_theme/watcher'
-require 'discourse_theme/scaffold'
+require_relative 'discourse_theme/version'
+require_relative 'discourse_theme/config'
+require_relative 'discourse_theme/cli'
+require_relative 'discourse_theme/client'
+require_relative 'discourse_theme/downloader'
+require_relative 'discourse_theme/uploader'
+require_relative 'discourse_theme/watcher'
+require_relative 'discourse_theme/scaffold'
 
 module DiscourseTheme
   class ThemeError < StandardError; end

--- a/lib/discourse_theme/watcher.rb
+++ b/lib/discourse_theme/watcher.rb
@@ -6,27 +6,7 @@ module DiscourseTheme
     end
 
     def watch
-      # Dir structure: https://meta.discourse.org/t/developer-s-guide-to-discourse-themes/93648#heading--2-c
-      # Regexr: https://regexr.com/4ba17
-      file_matcher = /
-        # Watch only recognized files
-        ^(?:
-          (?:
-            (common|desktop|mobile)\/
-            (?:
-              (?:header|after_header|footer|head_tag|body_tag)\.html?
-              |\1\.s?css
-            )
-          )
-          |common\/embedded\.s?css
-          |locales\/.+\.ya?ml
-          |settings\.ya?ml
-          |assets\/.+
-          |about\.json
-        )$
-      /x
-
-      listener = Listen.to(@dir, only: file_matcher) do |modified, added, removed|
+      listener = Listen.to(@dir, ignore: /^(?:\.|src\/)/) do |modified, added, removed|
         begin
           if modified.length == 1 &&
               added.length == 0 &&

--- a/lib/discourse_theme/watcher.rb
+++ b/lib/discourse_theme/watcher.rb
@@ -6,7 +6,27 @@ module DiscourseTheme
     end
 
     def watch
-      listener = Listen.to(@dir) do |modified, added, removed|
+      # Dir structure: https://meta.discourse.org/t/developer-s-guide-to-discourse-themes/93648#heading--2-c
+      # Regexr: https://regexr.com/4ba17
+      file_matcher = /
+        # Watch only recognized files
+        ^(?:
+          (?:
+            (common|desktop|mobile)\/
+            (?:
+              (?:header|after_header|footer|head_tag|body_tag)\.html?
+              |\1\.s?css
+            )
+          )
+          |common\/embedded\.s?css
+          |locales\/.+\.ya?ml
+          |settings\.ya?ml
+          |assets\/.+
+          |about\.json
+        )$
+      /x
+
+      listener = Listen.to(@dir, only: file_matcher) do |modified, added, removed|
         begin
           if modified.length == 1 &&
               added.length == 0 &&


### PR DESCRIPTION
Whitelist only relevant files to watch.

**Matches:**

```
about.json

assets/font.woff2
assets/background.jpg
assets/icon.svg

common/common.scss
common/head_tag.html
common/header.html
common/after_header.html
common/body_tag.html
common/footer.html
common/embedded.scss

desktop/desktop.scss
desktop/head_tag.html
desktop/header.html
desktop/after_header.html
desktop/body_tag.html
desktop/footer.html

mobile/mobile.scss
mobile/head_tag.html
mobile/header.html
mobile/after_header.html
mobile/body_tag.html
mobile/footer.html

settings.yml

locales/en.yml
locales/zh_CN.yml
```

**Doesn't match:**

```
src/thing.js
scripts/script.js
package.json
.gitignore
test/thing.test.js
LICENSE
README.md
```