### PR TITLE
FIX: comments make yml invalid

### DIFF
--- a/lib/discourse_theme/scaffold.rb
+++ b/lib/discourse_theme/scaffold.rb
@@ -60,11 +60,8 @@ module DiscourseTheme
 
     EN_YML = <<~YAML
       en:
-        #my_locale_key: My Translation
         theme_metadata:
           description: "#DESCRIPTION"
-          settings:
-            # my_setting_name: My Setting Description
     YAML
 
     def self.generate(dir)

--- a/lib/discourse_theme/version.rb
+++ b/lib/discourse_theme/version.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 module DiscourseTheme
-  VERSION = "0.5.0"
+  VERSION = "0.5.1"
 end


### PR DESCRIPTION
We might come up with a form which would work, but I would rather prefer we add some cli command later:

```
discourse_theme setting my_setting_name
```

Which would do the work.