### PR TITLE
FEATURE: Add basic-auth support

### DIFF
--- a/lib/discourse_theme/client.rb
+++ b/lib/discourse_theme/client.rb
@@ -105,7 +105,7 @@ module DiscourseTheme
     end
 
     def root
-      @url
+      URI.parse(@url).path
     end
 
     def is_theme_creator
@@ -116,6 +116,12 @@ module DiscourseTheme
 
     def request(request, never_404: false)
       uri = URI.parse(@url)
+
+      if uri.userinfo
+        username, password = uri.userinfo.split(":", 2)
+        request.basic_auth username, password
+      end
+
       http = Net::HTTP.new(uri.host, uri.port)
       http.use_ssl = URI::HTTPS === uri
       add_headers(request)

--- a/lib/discourse_theme/version.rb
+++ b/lib/discourse_theme/version.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 module DiscourseTheme
-  VERSION = "0.5.2"
+  VERSION = "0.6.0"
 end


### PR DESCRIPTION
URLs should be supplied in a format like `https://username:password@forum.example.com`