### PR TITLE
Add 'upload' command

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,10 @@ Downloads a theme from the server and stores in the designated directory.
 
 Monitors a theme or component for changes. When changed the program will synchronize the theme or component to your Discourse of choice.
 
+### `discourse_theme upload PATH`
+
+Uploads a theme to the server. Requires the theme to have been previously synchronized via `watch`.
+
 ## Contributing
 
 Bug reports and pull requests are welcome at [Meta Discourse](https://meta.discourse.org). This project is intended to be a safe, welcoming space for collaboration, and contributors are expected to adhere to the [Contributor Covenant](http://contributor-covenant.org) code of conduct.


### PR DESCRIPTION
Hello :wave:

We'd like to upload our theme as part of our continuous delivery pipeline, and figured the easiest way to do this was via the theme creator cli. Given there was no command to simply upload the theme, rather than watch for changes, we've added this command in.

The only point of contention that I could imagine with this PR is that the upload command doesn't take any inputs, and expects there to be a `theme_id` in the settings yml file. Generally this would mean the `watch` command has been run previously (or in our case, we'll just generate the yml file appropriately).

![thanks](https://i.giphy.com/media/3otPoOxyDTXjzpMbIY/giphy.gif)