### PR TITLE
DEV: Add common globals to `.eslintrc`

### DIFF
--- a/lib/discourse_theme/scaffold.rb
+++ b/lib/discourse_theme/scaffold.rb
@@ -47,7 +47,11 @@ module DiscourseTheme
 
     ESLINT_RC = <<~STR
       {
-        "extends": "eslint-config-discourse"
+        "extends": "eslint-config-discourse",
+        "globals": {
+          "settings": "readonly",
+          "themePrefix": "readonly"
+        }
       }
     STR
 


### PR DESCRIPTION
Adds the globals `settings` and `themePrefix` to the generated `.eslintrc` file so developers can use:
- `settings` when referencing theme settings
- `themePrefix()` when adding localizations