### PR TITLE
FIX: Avoid using path for root URL

### DIFF
--- a/lib/discourse_theme/client.rb
+++ b/lib/discourse_theme/client.rb
@@ -107,7 +107,7 @@ module DiscourseTheme
     end
 
     def root
-      URI.parse(@url).path
+      URI.parse(@url)
     end
 
     def is_theme_creator

--- a/lib/discourse_theme/version.rb
+++ b/lib/discourse_theme/version.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 module DiscourseTheme
-  VERSION = "0.7.1"
+  VERSION = "0.7.2"
 end


### PR DESCRIPTION
When the user enters 'https://discourse.theme-creator.io' we're
currently now returning an empty string for root because we're
invoking `path`. That's no good. This means `root+/about.json`
is just `/about.json` now.