### PR TITLE
FIX: auth in URL causes bad requests

### DIFF
--- a/discourse_theme.gemspec
+++ b/discourse_theme.gemspec
@@ -36,7 +36,8 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "minitest", "~> 5.0"
   spec.add_development_dependency "guard", "~> 2.14"
   spec.add_development_dependency "guard-minitest", "~> 2.4"
-  spec.add_development_dependency "webmock", "~> 3.5"
+  spec.add_development_dependency "webmock", "~> 3.17"
   spec.add_development_dependency "rubocop"
   spec.add_development_dependency "rubocop-discourse"
+  spec.add_development_dependency "m"
 end

--- a/lib/discourse_theme/client.rb
+++ b/lib/discourse_theme/client.rb
@@ -107,7 +107,12 @@ module DiscourseTheme
     end
 
     def root
-      URI.parse(@url)
+      parsed = URI.parse(@url)
+      # we must strip the username/password so it does not
+      # confuse AWS albs
+      parsed.user = nil
+      parsed.password = nil
+      parsed
     end
 
     def is_theme_creator

--- a/lib/discourse_theme/version.rb
+++ b/lib/discourse_theme/version.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 module DiscourseTheme
-  VERSION = "0.7.2"
+  VERSION = "0.7.3"
 end


### PR DESCRIPTION
Strip user and password from root, otherwise it confuses HTTP requests
which need to be explicit about basic auth
