### PR TITLE
FIX: parse root

### DIFF
--- a/lib/discourse_theme/client.rb
+++ b/lib/discourse_theme/client.rb
@@ -112,7 +112,7 @@ module DiscourseTheme
       # confuse AWS albs
       parsed.user = nil
       parsed.password = nil
-      parsed
+      parsed.to_s
     end
 
     def is_theme_creator

--- a/lib/discourse_theme/version.rb
+++ b/lib/discourse_theme/version.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 module DiscourseTheme
-  VERSION = "0.7.4"
+  VERSION = "0.7.5"
 end


### PR DESCRIPTION
Without an explicit to_s, root is still a URI - using `+` operator breaks subfolder as it clobbers existing paths.