### PR TITLE
FIX: Remove trailing slash when storing URL

### DIFF
--- a/test/test_cli.rb
+++ b/test/test_cli.rb
@@ -3,23 +3,41 @@ require "test_helper"
 require "base64"
 
 class TestCli < Minitest::Test
-
   def setup
     WebMock.reset!
     @dir = Dir.mktmpdir
 
-    @about_stub = stub_request(:get, "http://my.forum.com/about.json").
-      to_return(status: 200, body: { about: { version: "2.2.0" } }.to_json)
+    @root_stub =
+      stub_request(:get, "http://my.forum.com").to_return(status: 200, body: "", headers: {})
 
-    @themes_stub = stub_request(:get, "http://my.forum.com/admin/customize/themes.json").
-      to_return(status: 200, body: { themes: [{ id: 1, name: "Magic theme" }, { id: 5, name: "Amazing theme" }] }.to_json)
+    @about_stub =
+      stub_request(:get, "http://my.forum.com/about.json").to_return(
+        status: 200,
+        body: { about: { version: "2.2.0" } }.to_json,
+      )
 
-    @import_stub = stub_request(:post, "http://my.forum.com/admin/themes/import.json").
-      to_return(status: 200, body: { theme: { id: "6", name: "Uploaded theme", theme_fields: [] } }.to_json)
+    @themes_stub =
+      stub_request(:get, "http://my.forum.com/admin/customize/themes.json").to_return(
+        status: 200,
+        body: {
+          themes: [{ id: 1, name: "Magic theme" }, { id: 5, name: "Amazing theme" }],
+        }.to_json,
+      )
 
-    @download_tar_stub = stub_request(:get, "http://my.forum.com/admin/customize/themes/5/export").
-      to_return(status: 200, body: File.new("test/fixtures/discourse-test-theme.tar.gz"),
-                headers: { "content-disposition" => 'attachment; filename="testfile.tar.gz"' })
+    @import_stub =
+      stub_request(:post, "http://my.forum.com/admin/themes/import.json").to_return(
+        status: 200,
+        body: { theme: { id: "6", name: "Uploaded theme", theme_fields: [] } }.to_json,
+      )
+
+    @download_tar_stub =
+      stub_request(:get, "http://my.forum.com/admin/customize/themes/5/export").to_return(
+        status: 200,
+        body: File.new("test/fixtures/discourse-test-theme.tar.gz"),
+        headers: {
+          "content-disposition" => 'attachment; filename="testfile.tar.gz"',
+        },
+      )
 
     ENV["DISCOURSE_URL"] = "http://my.forum.com"
     ENV["DISCOURSE_API_KEY"] = "abc"
@@ -27,7 +45,7 @@ class TestCli < Minitest::Test
     DiscourseTheme::Watcher.return_immediately!
   end
 
-  DiscourseTheme::Cli.settings_file = Tempfile.new('settings')
+  DiscourseTheme::Cli.settings_file = Tempfile.new("settings")
 
   def teardown
     FileUtils.remove_dir(@dir)
@@ -35,8 +53,8 @@ class TestCli < Minitest::Test
 
   def suppress_output
     original_stdout, original_stderr = $stdout.clone, $stderr.clone
-    $stderr.reopen File.new('/dev/null', 'w')
-    $stdout.reopen File.new('/dev/null', 'w')
+    $stderr.reopen File.new("/dev/null", "w")
+    $stdout.reopen File.new("/dev/null", "w")
     yield
   ensure
     $stdout.reopen original_stdout
@@ -44,7 +62,7 @@ class TestCli < Minitest::Test
   end
 
   def settings
-    DiscourseTheme::Config.new(DiscourseTheme::Cli::settings_file)[@dir]
+    DiscourseTheme::Config.new(DiscourseTheme::Cli.settings_file)[@dir]
   end
 
   def test_watch
@@ -52,9 +70,7 @@ class TestCli < Minitest::Test
 
     # Stub interactive prompts to always return the first option, or "value"
     DiscourseTheme::UI.stub(:select, ->(question, options) { options[0] }) do
-      suppress_output do
-        DiscourseTheme::Cli.new.run(args)
-      end
+      suppress_output { DiscourseTheme::Cli.new.run(args) }
     end
 
     assert_requested(@about_stub, times: 1)
@@ -65,15 +81,28 @@ class TestCli < Minitest::Test
     assert_equal(settings.theme_id, 6)
   end
 
+  def test_watch_with_trailing_slash_in_url_removes_trailing_slash
+    ENV["DISCOURSE_URL"] = nil
+    args = ["watch", @dir]
+
+    DiscourseTheme::UI.stub(:select, ->(question, options) { options[0] }) do
+      DiscourseTheme::UI.stub(:ask, "http://my.forum.com/") do
+        DiscourseTheme::UI.stub(:yes?, true) do
+          suppress_output { DiscourseTheme::Cli.new.run(args) }
+        end
+      end
+    end
+
+    assert_equal(settings.url, "http://my.forum.com")
+  end
+
   def test_watch_with_basic_auth
     ENV["DISCOURSE_URL"] = "http://username:password@my.forum.com"
     args = ["watch", @dir]
 
     # Stub interactive prompts to always return the first option, or "value"
     DiscourseTheme::UI.stub(:select, ->(question, options) { options[0] }) do
-      suppress_output do
-        DiscourseTheme::Cli.new.run(args)
-      end
+      suppress_output { DiscourseTheme::Cli.new.run(args) }
     end
 
     expected_header = { "Authorization" => "Basic #{Base64.strict_encode64("username:password")}" }
@@ -90,36 +119,44 @@ class TestCli < Minitest::Test
     args = ["watch", @dir]
 
     questions_asked = []
-    DiscourseTheme::UI.stub(:select, ->(question, options) { questions_asked << question; options[0] }) do
-      suppress_output do
-        DiscourseTheme::Cli.new.run(args)
-      end
-    end
+    DiscourseTheme::UI.stub(
+      :select,
+      ->(question, options) do
+        questions_asked << question
+        options[0]
+      end,
+    ) { suppress_output { DiscourseTheme::Cli.new.run(args) } }
     assert(!questions_asked.join("\n").include?("child theme components"))
 
-    File.write(File.join(@dir, 'about.json'), { components: ["https://github.com/myorg/myrepo"] }.to_json)
+    File.write(
+      File.join(@dir, "about.json"),
+      { components: ["https://github.com/myorg/myrepo"] }.to_json,
+    )
 
     questions_asked = []
-    DiscourseTheme::UI.stub(:select, ->(question, options) { questions_asked << question; options[0] }) do
-      suppress_output do
-        DiscourseTheme::Cli.new.run(args)
-      end
-    end
+    DiscourseTheme::UI.stub(
+      :select,
+      ->(question, options) do
+        questions_asked << question
+        options[0]
+      end,
+    ) { suppress_output { DiscourseTheme::Cli.new.run(args) } }
     assert(questions_asked.join("\n").include?("child theme components"))
   end
 
   def test_upload
-    import_stub = stub_request(:post, "http://my.forum.com/admin/themes/import.json").
-      to_return(status: 200, body: { theme: { id: "1", name: "Existing theme", theme_fields: [] } }.to_json)
+    import_stub =
+      stub_request(:post, "http://my.forum.com/admin/themes/import.json").to_return(
+        status: 200,
+        body: { theme: { id: "1", name: "Existing theme", theme_fields: [] } }.to_json,
+      )
 
     args = ["upload", @dir]
 
     # Set an existing theme_id, as this is required for upload.
     settings.theme_id = 1
 
-    suppress_output do
-      DiscourseTheme::Cli.new.run(args)
-    end
+    suppress_output { DiscourseTheme::Cli.new.run(args) }
 
     assert_requested(@about_stub, times: 1)
     assert_requested(@themes_stub, times: 1)
@@ -130,17 +167,20 @@ class TestCli < Minitest::Test
   end
 
   def test_download
-    @download_zip_stub = stub_request(:get, "http://my.forum.com/admin/customize/themes/5/export").
-      to_return(status: 200, body: File.new("test/fixtures/discourse-test-theme.zip"),
-                headers: { "content-disposition" => 'attachment; filename="testfile.zip"' })
+    @download_zip_stub =
+      stub_request(:get, "http://my.forum.com/admin/customize/themes/5/export").to_return(
+        status: 200,
+        body: File.new("test/fixtures/discourse-test-theme.zip"),
+        headers: {
+          "content-disposition" => 'attachment; filename="testfile.zip"',
+        },
+      )
 
     args = ["download", @dir]
 
     DiscourseTheme::UI.stub(:select, ->(question, options) { options[0] }) do
       DiscourseTheme::UI.stub(:yes?, false) do
-        suppress_output do
-          DiscourseTheme::Cli.new.run(args)
-        end
+        suppress_output { DiscourseTheme::Cli.new.run(args) }
       end
     end
 
@@ -152,21 +192,39 @@ class TestCli < Minitest::Test
     # Check it got downloaded correctly
     Dir.chdir(@dir) do
       folders = Dir.glob("**/*").reject { |f| File.file?(f) }
-      assert(folders.sort == ["assets", "common", "locales", "mobile"].sort)
+      assert(folders.sort == %w[assets common locales mobile].sort)
 
       files = Dir.glob("**/*").reject { |f| File.directory?(f) }
-      assert(files.sort == ["about.json", "assets/logo.png", "common/body_tag.html", "locales/en.yml", "mobile/mobile.scss", "settings.yml"].sort)
+      assert(
+        files.sort ==
+          %w[
+            about.json
+            assets/logo.png
+            common/body_tag.html
+            locales/en.yml
+            mobile/mobile.scss
+            settings.yml
+          ].sort,
+      )
 
       assert(File.read("common/body_tag.html") == "<b>testtheme1</b>")
-      assert(File.read("mobile/mobile.scss") == "body {background-color: $background_color; font-size: $font-size}")
+      assert(
+        File.read("mobile/mobile.scss") ==
+          "body {background-color: $background_color; font-size: $font-size}",
+      )
       assert(File.read("settings.yml") == "somesetting: test")
     end
   end
 
   def test_download_zip
-    @download_zip_stub = stub_request(:get, "http://my.forum.com/admin/customize/themes/5/export").
-      to_return(status: 200, body: File.new("test/fixtures/discourse-test-theme.zip"),
-                headers: { "content-disposition" => 'attachment; filename="testfile.zip"' })
+    @download_zip_stub =
+      stub_request(:get, "http://my.forum.com/admin/customize/themes/5/export").to_return(
+        status: 200,
+        body: File.new("test/fixtures/discourse-test-theme.zip"),
+        headers: {
+          "content-disposition" => 'attachment; filename="testfile.zip"',
+        },
+      )
 
     test_download
   end
@@ -176,9 +234,7 @@ class TestCli < Minitest::Test
 
     DiscourseTheme::UI.stub(:ask, "my theme name") do
       DiscourseTheme::UI.stub(:yes?, false) do
-        suppress_output do
-          DiscourseTheme::Cli.new.run(args)
-        end
+        suppress_output { DiscourseTheme::Cli.new.run(args) }
       end
     end
 
@@ -191,7 +247,17 @@ class TestCli < Minitest::Test
     Dir.chdir(@dir) do
       list = files = Dir.glob("**/*").reject { |f| f.start_with?("node_modules/") }
       folders = list.reject { |f| File.file?(f) }
-      assert_equal(folders.sort, ["common", "locales", "node_modules", "javascripts", "javascripts/discourse", "javascripts/discourse/api-initializers"].sort)
+      assert_equal(
+        folders.sort,
+        %w[
+          common
+          locales
+          node_modules
+          javascripts
+          javascripts/discourse
+          javascripts/discourse/api-initializers
+        ].sort,
+      )
 
       files = list.reject { |f| File.directory?(f) }
       assert(files.include?("settings.yml"))
@@ -203,5 +269,4 @@ class TestCli < Minitest::Test
       assert(files.include?("locales/en.yml"))
     end
   end
-
 end


### PR DESCRIPTION
Why is this change required?

Before this change, a user can specify the URL as `http://example.com` or `http://example.com/` but this will be treated as different URLs when stored in the settings file. There is no need for us to make this distinction and can potentially lead to a poor experience when using the CLI since users are prompted to enter an API key again if they use `http://example.com/` when the API key has already been stored under `http://example.com`

Review notes:

Our editors are all configured to format on save with stree so alot of the changes here are just formatting changes. I've left comments along the lines where the changes are made.