### PR TITLE
FEATURE: Add `discourse_theme rspec <path to spec files>` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,15 @@ Monitors a theme or component for changes. When changed the program will synchro
 
 Uploads a theme to the server. Requires the theme to have been previously synchronized via `watch`.
 
+### `discourse_theme rspec PATH`
+
+Runs the [RSpec](https://rspec.info/) system tests under the `spec` folder for the theme.
+
+Requires [Docker](https://docs.docker.com/engine/install/) to be installed as the tests are ran in a Docker container with
+the Discourse test environment configured.
+
+When the `--headless` option is used, a local installation of the [Google Chrome browser](https://www.google.com/chrome/) is required.
+
 ## Contributing
 
 Bug reports and pull requests are welcome at [Meta Discourse](https://meta.discourse.org). This project is intended to be a safe, welcoming space for collaboration, and contributors are expected to adhere to the [Contributor Covenant](http://contributor-covenant.org) code of conduct.

--- a/discourse_theme.gemspec
+++ b/discourse_theme.gemspec
@@ -28,6 +28,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "multipart-post", "~> 2.0"
   spec.add_runtime_dependency "tty-prompt", "~> 0.18"
   spec.add_runtime_dependency "rubyzip", "~> 1.2"
+  spec.add_runtime_dependency "selenium-webdriver", "> 4.11"
 
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake"
@@ -40,4 +41,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "m"
   spec.add_development_dependency "syntax_tree"
   spec.add_development_dependency "syntax_tree-disable_ternary"
+  spec.add_development_dependency "mocha"
 end

--- a/lib/discourse_theme/cli.rb
+++ b/lib/discourse_theme/cli.rb
@@ -228,6 +228,8 @@ module DiscourseTheme
             execute(command: "docker rm -f #{container_name}")
           end
 
+          image = "discourse/discourse_test:release"
+
           execute(
             command: <<~CMD.squeeze(" "),
               docker run -d \
@@ -235,10 +237,11 @@ module DiscourseTheme
                 --add-host host.docker.internal:host-gateway \
                 --entrypoint=/sbin/boot \
                 --name=#{container_name} \
+                --pull=always \
                 -v #{DISCOURSE_THEME_TEST_TMP_DIR}:/tmp \
-                discourse/discourse_test:release
+                #{image}
             CMD
-            message: "Creating discourse/discourse_test:release Docker container...",
+            message: "Creating #{image} Docker container...",
             stream: verbose,
           )
 

--- a/lib/discourse_theme/cli.rb
+++ b/lib/discourse_theme/cli.rb
@@ -268,7 +268,7 @@ module DiscourseTheme
 
         execute(
           command:
-            "docker exec #{rspec_envs} -u discourse:discourse #{container_name} bundle exec rspec --color --tty #{File.join("/tmp", basename, spec_path)}".squeeze(
+            "docker exec #{rspec_envs} -t -u discourse:discourse #{container_name} bundle exec rspec #{File.join("/tmp", basename, spec_path)}".squeeze(
               " ",
             ),
           stream: true,

--- a/lib/discourse_theme/cli.rb
+++ b/lib/discourse_theme/cli.rb
@@ -251,7 +251,7 @@ module DiscourseTheme
 
           execute(
             command:
-              "docker exec -u discourse:discourse #{container_name} bundle exec rake docker:test:setup",
+              "docker exec -e SKIP_MULTISITE=1 -u discourse:discourse #{container_name} bundle exec rake docker:test:setup",
             message: "Setting up Discourse test environment...",
             stream: verbose,
           )

--- a/lib/discourse_theme/cli.rb
+++ b/lib/discourse_theme/cli.rb
@@ -201,7 +201,9 @@ module DiscourseTheme
 
         if !(
              output =
-               execute(command: "docker ps -a --format '{{json .}}' | grep #{container_name}")
+               execute(
+                 command: "docker ps -a --filter name=#{container_name} --format '{{json .}}'",
+               )
            ).empty?
           container_exists = true
           is_running = JSON.parse(output)["State"] == "running"

--- a/lib/discourse_theme/cli.rb
+++ b/lib/discourse_theme/cli.rb
@@ -266,7 +266,12 @@ module DiscourseTheme
         rspec_envs = []
 
         if headless
-          WebDriver.start(browser: :chrome)
+          container_ip =
+            execute(
+              command: "docker inspect #{container_name} --format '{{.NetworkSettings.IPAddress}}'",
+            )
+
+          WebDriver.start_chrome(allowed_origin: "host.docker.internal", allowed_ip: container_ip)
 
           rspec_envs.push("SELENIUM_HEADLESS=0")
           rspec_envs.push("CAPYBARA_SERVER_HOST=0.0.0.0")

--- a/lib/discourse_theme/cli.rb
+++ b/lib/discourse_theme/cli.rb
@@ -307,7 +307,6 @@ module DiscourseTheme
     def execute(command:, message: nil, exit_on_error: true, stream: false)
       UI.progress(message) if message
 
-      # stdout, stderr, status = Open3.capture3(command)
       success = false
       output = +""
 

--- a/lib/discourse_theme/web_driver.rb
+++ b/lib/discourse_theme/web_driver.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require "selenium-webdriver"
+
+module DiscourseTheme
+  class WebDriver
+    def self.start(browser: :chrome)
+      case browser
+      when :chrome
+        service = Selenium::WebDriver::Service.chrome
+        options = Selenium::WebDriver::Options.chrome
+        service.executable_path = Selenium::WebDriver::DriverFinder.path(options, service.class)
+        service.args = %w[--whitelisted-ips --allowed-origins=*]
+        service.launch
+      else
+        raise "Unsupported browser: #{browser}"
+      end
+    end
+  end
+end

--- a/lib/discourse_theme/web_driver.rb
+++ b/lib/discourse_theme/web_driver.rb
@@ -4,17 +4,12 @@ require "selenium-webdriver"
 
 module DiscourseTheme
   class WebDriver
-    def self.start(browser: :chrome)
-      case browser
-      when :chrome
-        service = Selenium::WebDriver::Service.chrome
-        options = Selenium::WebDriver::Options.chrome
-        service.executable_path = Selenium::WebDriver::DriverFinder.path(options, service.class)
-        service.args = %w[--whitelisted-ips --allowed-origins=*]
-        service.launch
-      else
-        raise "Unsupported browser: #{browser}"
-      end
+    def self.start_chrome(allowed_ip:, allowed_origin:)
+      service = Selenium::WebDriver::Service.chrome
+      options = Selenium::WebDriver::Options.chrome
+      service.executable_path = Selenium::WebDriver::DriverFinder.path(options, service.class)
+      service.args = ["--allowed-ips=#{allowed_ip}", "--allowed-origins=#{allowed_origin}"]
+      service.launch
     end
   end
 end

--- a/test/test_cli.rb
+++ b/test/test_cli.rb
@@ -331,7 +331,7 @@ class TestCli < Minitest::Test
 
       cli.expects(:execute).with(
         command:
-          "docker exec -u discourse:discourse #{DiscourseTheme::Cli::DISCOURSE_TEST_DOCKER_CONTAINER_NAME} bundle exec rake docker:test:setup",
+          "docker exec -e SKIP_MULTISITE=1 -u discourse:discourse #{DiscourseTheme::Cli::DISCOURSE_TEST_DOCKER_CONTAINER_NAME} bundle exec rake docker:test:setup",
         message: "Setting up Discourse test environment...",
         stream: verbose,
       )

--- a/test/test_cli.rb
+++ b/test/test_cli.rb
@@ -345,7 +345,20 @@ class TestCli < Minitest::Test
     end
 
     if headless
-      DiscourseTheme::WebDriver.expects(:start).with(browser: :chrome)
+      fake_ip = "123.456.789"
+
+      cli
+        .expects(:execute)
+        .with(
+          command:
+            "docker inspect #{DiscourseTheme::Cli::DISCOURSE_TEST_DOCKER_CONTAINER_NAME} --format '{{.NetworkSettings.IPAddress}}'",
+        )
+        .returns(fake_ip)
+
+      DiscourseTheme::WebDriver.expects(:start_chrome).with(
+        allowed_ip: fake_ip,
+        allowed_origin: "host.docker.internal",
+      )
 
       cli.expects(:execute).with(
         command:

--- a/test/test_cli.rb
+++ b/test/test_cli.rb
@@ -315,6 +315,7 @@ class TestCli < Minitest::Test
             --add-host host.docker.internal:host-gateway \
             --entrypoint=/sbin/boot \
             --name=#{DiscourseTheme::Cli::DISCOURSE_TEST_DOCKER_CONTAINER_NAME} \
+            --pull=always \
             -v #{DiscourseTheme::Cli::DISCOURSE_THEME_TEST_TMP_DIR}:/tmp \
             discourse/discourse_test:release
         COMMAND

--- a/test/test_cli.rb
+++ b/test/test_cli.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require "test_helper"
 require "base64"
-
+require "mocha/minitest"
 class TestCli < Minitest::Test
   def setup
     WebMock.reset!
@@ -268,5 +268,213 @@ class TestCli < Minitest::Test
       assert(File.exist?(".template-lintrc.js"))
       assert(files.include?("locales/en.yml"))
     end
+  end
+
+  def mock_rspec_docker_commands(
+    cli,
+    verbose:,
+    setup_commands:,
+    rspec_path: "/spec",
+    container_state: nil,
+    headless: false
+  )
+    cli
+      .expects(:execute)
+      .with(
+        command:
+          "docker ps -a --format '{{json .}}' | grep #{DiscourseTheme::Cli::DISCOURSE_TEST_DOCKER_CONTAINER_NAME}",
+      )
+      .returns(
+        (
+          if container_state
+            %({"Names":"#{DiscourseTheme::Cli::DISCOURSE_TEST_DOCKER_CONTAINER_NAME}","State":"#{container_state}"})
+          else
+            ""
+          end
+        ),
+      )
+
+    if setup_commands
+      if container_state
+        cli.expects(:execute).with(
+          command: "docker stop #{DiscourseTheme::Cli::DISCOURSE_TEST_DOCKER_CONTAINER_NAME}",
+        )
+
+        cli.expects(:execute).with(
+          command: "docker rm -f #{DiscourseTheme::Cli::DISCOURSE_TEST_DOCKER_CONTAINER_NAME}",
+        )
+      end
+
+      cli.expects(:execute).with(
+        command: <<~COMMAND.squeeze(" "),
+          docker run -d \
+            -p 31337:31337 \
+            --add-host host.docker.internal:host-gateway \
+            --entrypoint=/sbin/boot \
+            --name=#{DiscourseTheme::Cli::DISCOURSE_TEST_DOCKER_CONTAINER_NAME} \
+            -v #{@dir}:#{@dir} \
+            discourse/discourse_test:release
+        COMMAND
+        message: "Creating discourse/discourse_test:release Docker container...",
+        stream: verbose,
+      )
+
+      cli.expects(:execute).with(
+        command:
+          "docker exec -u discourse:discourse #{DiscourseTheme::Cli::DISCOURSE_TEST_DOCKER_CONTAINER_NAME} ruby script/docker_test.rb --no-tests --checkout-ref origin/tests-passed",
+        message: "Checking out latest Discourse source code...",
+        stream: verbose,
+      )
+
+      cli.expects(:execute).with(
+        command:
+          "docker exec -u discourse:discourse #{DiscourseTheme::Cli::DISCOURSE_TEST_DOCKER_CONTAINER_NAME} bundle exec rake docker:test:setup",
+        message: "Setting up Discourse test environment...",
+        stream: verbose,
+      )
+
+      cli.expects(:execute).with(
+        command:
+          "docker exec -u discourse:discourse #{DiscourseTheme::Cli::DISCOURSE_TEST_DOCKER_CONTAINER_NAME} bin/ember-cli --build",
+        message: "Building Ember CLI assets...",
+        stream: verbose,
+      )
+    end
+
+    if headless
+      DiscourseTheme::WebDriver.expects(:start).with(browser: :chrome)
+
+      cli.expects(:execute).with(
+        command:
+          "docker exec -e SELENIUM_HEADLESS=0 -e CAPYBARA_SERVER_HOST=0.0.0.0 -e CAPYBARA_REMOTE_DRIVER_URL=http://host.docker.internal:9515 -u discourse:discourse #{DiscourseTheme::Cli::DISCOURSE_TEST_DOCKER_CONTAINER_NAME} bundle exec rspec --color --tty #{@dir}#{rspec_path}",
+        stream: true,
+      )
+    else
+      cli.expects(:execute).with(
+        command:
+          "docker exec -u discourse:discourse #{DiscourseTheme::Cli::DISCOURSE_TEST_DOCKER_CONTAINER_NAME} bundle exec rspec --color --tty #{@dir}#{rspec_path}",
+        stream: true,
+      )
+    end
+  end
+
+  def test_rspec
+    args = ["rspec", @dir]
+
+    cli = DiscourseTheme::Cli.new
+    mock_rspec_docker_commands(cli, verbose: false, setup_commands: true)
+
+    suppress_output { cli.run(args) }
+  end
+
+  def test_rspec_with_headless_option
+    args = ["rspec", @dir, "--headless"]
+
+    cli = DiscourseTheme::Cli.new
+    mock_rspec_docker_commands(cli, verbose: false, setup_commands: true, headless: true)
+
+    suppress_output { cli.run(args) }
+  end
+
+  def test_rspec_with_verbose_option
+    args = ["rspec", @dir, "--verbose"]
+
+    cli = DiscourseTheme::Cli.new
+    mock_rspec_docker_commands(cli, verbose: true, setup_commands: true)
+
+    suppress_output { cli.run(args) }
+  end
+
+  def test_rspec_with_rebuild_option
+    args = ["rspec", @dir, "--rebuild"]
+
+    cli = DiscourseTheme::Cli.new
+
+    mock_rspec_docker_commands(
+      cli,
+      verbose: false,
+      setup_commands: true,
+      container_state: "running",
+    )
+
+    suppress_output { cli.run(args) }
+  end
+
+  def test_rspec_when_docker_container_is_already_running
+    args = ["rspec", @dir]
+
+    cli = DiscourseTheme::Cli.new
+
+    mock_rspec_docker_commands(
+      cli,
+      verbose: false,
+      setup_commands: false,
+      container_state: "running",
+    )
+
+    suppress_output { cli.run(args) }
+  end
+
+  def test_rspec_with_dir_path_to_rspec_folder
+    args = ["rspec", File.join(@dir, "/spec")]
+
+    cli = DiscourseTheme::Cli.new
+
+    mock_rspec_docker_commands(
+      cli,
+      verbose: false,
+      setup_commands: false,
+      container_state: "running",
+    )
+
+    suppress_output { cli.run(args) }
+  end
+
+  def test_rspec_with_dir_path_to_custom_rspec_folder
+    args = ["rspec", File.join(@dir, "/spec/system")]
+
+    cli = DiscourseTheme::Cli.new
+
+    mock_rspec_docker_commands(
+      cli,
+      verbose: false,
+      setup_commands: false,
+      rspec_path: "/spec/system",
+      container_state: "running",
+    )
+
+    suppress_output { cli.run(args) }
+  end
+
+  def test_rspec_with_dir_path_to_rspec_file
+    args = ["rspec", File.join(@dir, "/spec/system/some_test_rspec.rb")]
+
+    cli = DiscourseTheme::Cli.new
+
+    mock_rspec_docker_commands(
+      cli,
+      verbose: false,
+      setup_commands: false,
+      rspec_path: "/spec/system/some_test_rspec.rb",
+      container_state: "running",
+    )
+
+    suppress_output { cli.run(args) }
+  end
+
+  def test_rspec_with_dir_path_to_rspec_file_with_line_number
+    args = ["rspec", File.join(@dir, "/spec/system/some_test_rspec.rb:3")]
+
+    cli = DiscourseTheme::Cli.new
+
+    mock_rspec_docker_commands(
+      cli,
+      verbose: false,
+      setup_commands: false,
+      rspec_path: "/spec/system/some_test_rspec.rb:3",
+      container_state: "running",
+    )
+
+    suppress_output { cli.run(args) }
   end
 end

--- a/test/test_cli.rb
+++ b/test/test_cli.rb
@@ -282,7 +282,7 @@ class TestCli < Minitest::Test
       .expects(:execute)
       .with(
         command:
-          "docker ps -a --format '{{json .}}' | grep #{DiscourseTheme::Cli::DISCOURSE_TEST_DOCKER_CONTAINER_NAME}",
+          "docker ps -a --filter name=#{DiscourseTheme::Cli::DISCOURSE_TEST_DOCKER_CONTAINER_NAME} --format '{{json .}}'",
       )
       .returns(
         (

--- a/test/test_cli.rb
+++ b/test/test_cli.rb
@@ -346,13 +346,13 @@ class TestCli < Minitest::Test
 
       cli.expects(:execute).with(
         command:
-          "docker exec -e SELENIUM_HEADLESS=0 -e CAPYBARA_SERVER_HOST=0.0.0.0 -e CAPYBARA_REMOTE_DRIVER_URL=http://host.docker.internal:9515 -u discourse:discourse #{DiscourseTheme::Cli::DISCOURSE_TEST_DOCKER_CONTAINER_NAME} bundle exec rspec --color --tty #{@dir}#{rspec_path}",
+          "docker exec -e SELENIUM_HEADLESS=0 -e CAPYBARA_SERVER_HOST=0.0.0.0 -e CAPYBARA_REMOTE_DRIVER_URL=http://host.docker.internal:9515 -t -u discourse:discourse #{DiscourseTheme::Cli::DISCOURSE_TEST_DOCKER_CONTAINER_NAME} bundle exec rspec #{@dir}#{rspec_path}",
         stream: true,
       )
     else
       cli.expects(:execute).with(
         command:
-          "docker exec -u discourse:discourse #{DiscourseTheme::Cli::DISCOURSE_TEST_DOCKER_CONTAINER_NAME} bundle exec rspec --color --tty #{@dir}#{rspec_path}",
+          "docker exec -t -u discourse:discourse #{DiscourseTheme::Cli::DISCOURSE_TEST_DOCKER_CONTAINER_NAME} bundle exec rspec #{@dir}#{rspec_path}",
         stream: true,
       )
     end


### PR DESCRIPTION
What does this change do?

This commit adds the `rspec` command to the `discourse_theme` CLI so
that themes can write system specs and run them easily without the need
to set up a local Discourse development environment.

Example:

```
discourse_theme rspec /path/to/theme
```

or

```
discourse_theme rspec /path/to/theme/spec/specific-folder
```

or

```
discourse_theme rspec /path/to/theme/spec/specific_rspec_file.rb
```

or

```
discourse_theme rspec
/path/to/theme/spec/specific_rspec_file_with_line_number.rb:3
```

Under the hood, the command runs a Docker container using the
`discourse/discourse_test:release` image and sets up the test
environment. This does mean the first run will incur some overhead and
there are ways to reduce this overhead but I will address them in
subsequent PRs. Once the Docker container is running, it simply runs
`bundle exec rspec` in the Docker container for the path that is given.

When running system specs, the `--headless` option can also be used to
run the system specs in headless mode. While we can't run a non-headless
chrome browser in the container, we can run a chrome browser locally and ask the
Rails system test to connect to the local browser. This is done by
having the CLI start a `chromedriver` instance locally and then passing
the `CAPYBARA_SERVER_HOST` and `CAPYBARA_REMOTE_DRIVER_URL` env
variables when running the RSpec command.