### PR TITLE
DEV: Format files with syntax tree

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,6 @@ jobs:
     strategy:
       matrix:
         ruby:
-          - "2.7"
           - "3.0"
           - "3.1"
           - "3.2"
@@ -29,6 +28,11 @@ jobs:
 
       - name: Lint
         run: bundle exec rubocop
+
+      - name: syntax_tree
+        run: |
+          bundle exec stree check Gemfile $(git ls-files '*.rb') $(git ls-files '*.rake') $(git ls-files '*.thor')
+
 
       - name: Tests
         run: bundle exec rake test

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,5 @@
 inherit_gem:
-  rubocop-discourse: default.yml
+  rubocop-discourse: stree-compat.yml
 inherit_mode:
   merge:
     - Exclude

--- a/.streerc
+++ b/.streerc
@@ -1,0 +1,2 @@
+--print-width=100
+--plugins=plugin/trailing_comma,disable_ternary

--- a/discourse_theme.gemspec
+++ b/discourse_theme.gemspec
@@ -5,25 +5,23 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require "discourse_theme/version"
 
 Gem::Specification.new do |spec|
-  spec.name          = "discourse_theme"
-  spec.version       = DiscourseTheme::VERSION
-  spec.authors       = ["Sam Saffron"]
-  spec.email         = ["sam.saffron@gmail.com"]
+  spec.name = "discourse_theme"
+  spec.version = DiscourseTheme::VERSION
+  spec.authors = ["Sam Saffron"]
+  spec.email = ["sam.saffron@gmail.com"]
 
-  spec.summary       = %q{CLI helper for creating Discourse themes}
-  spec.description   = %q{CLI helper for creating Discourse themes}
-  spec.homepage      = "https://github.com/discourse/discourse_theme"
-  spec.license       = "MIT"
+  spec.summary = "CLI helper for creating Discourse themes"
+  spec.description = "CLI helper for creating Discourse themes"
+  spec.homepage = "https://github.com/discourse/discourse_theme"
+  spec.license = "MIT"
 
-  spec.files         = `git ls-files -z`.split("\x0").reject do |f|
-    f.match(%r{^(test|spec|features)/})
-  end
+  spec.files = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
 
-  spec.bindir        = "bin"
-  spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
+  spec.bindir = "bin"
+  spec.executables = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.required_ruby_version = '>= 2.5.0'
+  spec.required_ruby_version = ">= 3.0.0"
 
   spec.add_runtime_dependency "minitar", "~> 0.6"
   spec.add_runtime_dependency "listen", "~> 3.1"
@@ -31,13 +29,15 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "tty-prompt", "~> 0.18"
   spec.add_runtime_dependency "rubyzip", "~> 1.2"
 
-  spec.add_development_dependency "bundler", "~> 2.0"
-  spec.add_development_dependency "rake", "~> 13.0"
-  spec.add_development_dependency "minitest", "~> 5.0"
-  spec.add_development_dependency "guard", "~> 2.14"
-  spec.add_development_dependency "guard-minitest", "~> 2.4"
-  spec.add_development_dependency "webmock", "~> 3.17"
+  spec.add_development_dependency "bundler"
+  spec.add_development_dependency "rake"
+  spec.add_development_dependency "minitest"
+  spec.add_development_dependency "guard"
+  spec.add_development_dependency "guard-minitest"
+  spec.add_development_dependency "webmock"
   spec.add_development_dependency "rubocop"
   spec.add_development_dependency "rubocop-discourse"
   spec.add_development_dependency "m"
+  spec.add_development_dependency "syntax_tree"
+  spec.add_development_dependency "syntax_tree-disable_ternary"
 end

--- a/lib/discourse_theme.rb
+++ b/lib/discourse_theme.rb
@@ -1,29 +1,30 @@
 # frozen_string_literal: true
-require 'fileutils'
-require 'pathname'
-require 'tempfile'
-require 'securerandom'
-require 'minitar'
-require 'zlib'
-require 'find'
-require 'net/http'
-require 'net/http/post/multipart'
-require 'uri'
-require 'listen'
-require 'json'
-require 'yaml'
-require 'tty/prompt'
+require "fileutils"
+require "pathname"
+require "tempfile"
+require "securerandom"
+require "minitar"
+require "zlib"
+require "find"
+require "net/http"
+require "net/http/post/multipart"
+require "uri"
+require "listen"
+require "json"
+require "yaml"
+require "tty/prompt"
 
-require_relative 'discourse_theme/version'
-require_relative 'discourse_theme/config'
-require_relative 'discourse_theme/ui'
-require_relative 'discourse_theme/cli'
-require_relative 'discourse_theme/client'
-require_relative 'discourse_theme/downloader'
-require_relative 'discourse_theme/uploader'
-require_relative 'discourse_theme/watcher'
-require_relative 'discourse_theme/scaffold'
+require_relative "discourse_theme/version"
+require_relative "discourse_theme/config"
+require_relative "discourse_theme/ui"
+require_relative "discourse_theme/cli"
+require_relative "discourse_theme/client"
+require_relative "discourse_theme/downloader"
+require_relative "discourse_theme/uploader"
+require_relative "discourse_theme/watcher"
+require_relative "discourse_theme/scaffold"
 
 module DiscourseTheme
-  class ThemeError < StandardError; end
+  class ThemeError < StandardError
+  end
 end

--- a/lib/discourse_theme/client.rb
+++ b/lib/discourse_theme/client.rb
@@ -44,7 +44,15 @@ module DiscourseTheme
     end
 
     def get_themes_list
-      endpoint = root + (@is_theme_creator ? "/user_themes.json" : "/admin/customize/themes.json")
+      endpoint =
+        root +
+          (
+            if @is_theme_creator
+              "/user_themes.json"
+            else
+              "/admin/customize/themes.json"
+            end
+          )
 
       response = request(Net::HTTP::Get.new(endpoint), never_404: true)
       json = JSON.parse(response.body)
@@ -54,7 +62,13 @@ module DiscourseTheme
     def get_raw_theme_export(id)
       endpoint =
         root +
-          (@is_theme_creator ? "/user_themes/#{id}/export" : "/admin/customize/themes/#{id}/export")
+          (
+            if @is_theme_creator
+              "/user_themes/#{id}/export"
+            else
+              "/admin/customize/themes/#{id}/export"
+            end
+          )
 
       response = request(Net::HTTP::Get.new endpoint)
       raise "Error downloading theme: #{response.code}" unless response.code.to_i == 200
@@ -72,7 +86,14 @@ module DiscourseTheme
 
     def upload_full_theme(tgz, theme_id:, components:)
       endpoint =
-        root + (@is_theme_creator ? "/user_themes/import.json" : "/admin/themes/import.json")
+        root +
+          (
+            if @is_theme_creator
+              "/user_themes/import.json"
+            else
+              "/admin/themes/import.json"
+            end
+          )
 
       post =
         Net::HTTP::Post::Multipart.new(

--- a/lib/discourse_theme/config.rb
+++ b/lib/discourse_theme/config.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 class DiscourseTheme::Config
-
   class PathSetting
     def initialize(config, path)
       @config = config
@@ -79,7 +78,7 @@ class DiscourseTheme::Config
       begin
         @raw_config = YAML.load_file(@filename)
         raise unless Hash === @raw_config
-      rescue
+      rescue StandardError
         @raw_config = {}
         $stderr.puts "ERROR: #{@filename} contains invalid config, resetting"
       end

--- a/lib/discourse_theme/downloader.rb
+++ b/lib/discourse_theme/downloader.rb
@@ -1,8 +1,7 @@
 # frozen_string_literal: true
-require 'zip'
+require "zip"
 
 class DiscourseTheme::Downloader
-
   def initialize(dir:, client:)
     @dir = dir
     @client = client
@@ -26,7 +25,7 @@ class DiscourseTheme::Downloader
 
       # Minitar extracts into a sub directory, move all the files up one dir
       Dir.chdir(@dir) do
-        folders = Dir.glob('*/')
+        folders = Dir.glob("*/")
         raise "Extraction failed" unless folders.length == 1
         FileUtils.mv(Dir.glob("#{folders[0]}*"), "./")
         FileUtils.remove_dir(folders[0])
@@ -37,8 +36,6 @@ class DiscourseTheme::Downloader
   private
 
   def add_headers(request)
-    if @is_theme_creator
-      request["User-Api-Key"] = @api_key
-    end
+    request["User-Api-Key"] = @api_key if @is_theme_creator
   end
 end

--- a/lib/discourse_theme/scaffold.rb
+++ b/lib/discourse_theme/scaffold.rb
@@ -1,15 +1,15 @@
 # frozen_string_literal: true
 
-require 'date'
-require 'json'
+require "date"
+require "json"
 
 module DiscourseTheme
   class Scaffold
-
     ABOUT_JSON = {
       about_url: "TODO: Put your theme's public repo or Meta topic URL here",
       license_url: "TODO: Put your theme's LICENSE URL here",
-      assets: {}
+      assets: {
+      },
     }
 
     HELP = <<~STR
@@ -93,27 +93,29 @@ module DiscourseTheme
     def self.generate(dir)
       UI.progress "Generating a scaffold theme at #{dir}"
 
-      name = loop do
-        input = UI.ask("What would you like to call your theme?").to_s.strip
-        if input.empty?
-          UI.error("Theme name cannot be empty")
-        else
-          break input
+      name =
+        loop do
+          input = UI.ask("What would you like to call your theme?").to_s.strip
+          if input.empty?
+            UI.error("Theme name cannot be empty")
+          else
+            break input
+          end
         end
-      end
 
       is_component = UI.yes?("Is this a component?")
 
       FileUtils.mkdir_p dir
       Dir.chdir dir do
-        author = loop do
-          input = UI.ask("Who is authoring the theme?", default: ENV['USER']).to_s.strip
-          if input.empty?
-            UI.error("Author cannot be empty")
-          else
-            break input
+        author =
+          loop do
+            input = UI.ask("Who is authoring the theme?", default: ENV["USER"]).to_s.strip
+            if input.empty?
+              UI.error("Author cannot be empty")
+            else
+              break input
+            end
           end
-        end
 
         description = UI.ask("How would you describe this theme?").to_s.strip
 
@@ -125,19 +127,19 @@ module DiscourseTheme
           about_template[:color_schemes] = {}
         end
 
-        encoded_name = name.downcase.gsub(/[^a-zA-Z0-9_-]+/, '_')
+        encoded_name = name.downcase.gsub(/[^a-zA-Z0-9_-]+/, "_")
 
-        write('about.json', JSON.pretty_generate(about_template))
-        write('HELP', HELP)
-        write('LICENSE', LICENSE.sub("#YEAR", "#{Date.today.year}").sub("#AUTHOR", author))
-        write('.eslintrc', ESLINT_RC)
-        write('.gitignore', GIT_IGNORE)
-        write('.template-lintrc.js', TEMPLATE_LINT_RC)
-        write('package.json', PACKAGE_JSON.sub("#AUTHOR", author))
-        write('settings.yml', SETTINGS_YML)
-        write('common/common.scss', '')
+        write("about.json", JSON.pretty_generate(about_template))
+        write("HELP", HELP)
+        write("LICENSE", LICENSE.sub("#YEAR", "#{Date.today.year}").sub("#AUTHOR", author))
+        write(".eslintrc", ESLINT_RC)
+        write(".gitignore", GIT_IGNORE)
+        write(".template-lintrc.js", TEMPLATE_LINT_RC)
+        write("package.json", PACKAGE_JSON.sub("#AUTHOR", author))
+        write("settings.yml", SETTINGS_YML)
+        write("common/common.scss", "")
         write("javascripts/discourse/api-initializers/#{encoded_name}.js", API_INITIALIZER)
-        write('locales/en.yml', EN_YML.sub("#DESCRIPTION", description))
+        write("locales/en.yml", EN_YML.sub("#DESCRIPTION", description))
 
         UI.info "Initializing git repo"
         puts `git init && git symbolic-ref HEAD refs/heads/main`

--- a/lib/discourse_theme/uploader.rb
+++ b/lib/discourse_theme/uploader.rb
@@ -9,13 +9,13 @@ module DiscourseTheme
     end
 
     def compress_dir(gzip, dir)
-      sgz = Zlib::GzipWriter.new(File.open(gzip, 'wb'))
+      sgz = Zlib::GzipWriter.new(File.open(gzip, "wb"))
       tar = Archive::Tar::Minitar::Output.new(sgz)
 
       Dir.chdir(dir + "/../") do
         Find.find(File.basename(dir)) do |x|
           bn = File.basename(x)
-          Find.prune if bn == "node_modules" || bn == "src" || bn[0] == ?.
+          Find.prune if bn == "node_modules" || bn == "src" || bn[0] == "."
           next if File.directory?(x)
 
           Minitar.pack_file(x, tar)
@@ -39,25 +39,18 @@ module DiscourseTheme
       count
     end
 
-    def upload_theme_field(target: , name: , type_id: , value:)
+    def upload_theme_field(target:, name:, type_id:, value:)
       raise "expecting theme_id to be set!" unless @theme_id
 
       args = {
         theme: {
-          theme_fields: [{
-            name: name,
-            target: target,
-            type_id: type_id,
-            value: value
-          }]
-        }
+          theme_fields: [{ name: name, target: target, type_id: type_id, value: value }],
+        },
       }
 
       response = @client.update_theme(@theme_id, args)
       json = JSON.parse(response.body)
-        if diagnose_errors(json) != 0
-          UI.error "(end of errors)"
-        end
+      UI.error "(end of errors)" if diagnose_errors(json) != 0
     end
 
     def upload_full_theme
@@ -69,14 +62,11 @@ module DiscourseTheme
 
         json = JSON.parse(response.body)
         @theme_id = json["theme"]["id"]
-        if diagnose_errors(json) != 0
-          UI.error "(end of errors)"
-        end
+        UI.error "(end of errors)" if diagnose_errors(json) != 0
         @theme_id
       end
     ensure
       FileUtils.rm_f filename
     end
-
   end
 end

--- a/lib/discourse_theme/watcher.rb
+++ b/lib/discourse_theme/watcher.rb
@@ -15,38 +15,36 @@ module DiscourseTheme
     end
 
     def watch
-      listener = Listen.to(@dir) do |modified, added, removed|
-        begin
-          if modified.length == 1 &&
-              added.length == 0 &&
-              removed.length == 0 &&
-              (resolved = resolve_file(modified[0]))
+      listener =
+        Listen.to(@dir) do |modified, added, removed|
+          begin
+            if modified.length == 1 && added.length == 0 && removed.length == 0 &&
+                 (resolved = resolve_file(modified[0]))
+              target, name, type_id = resolved
+              UI.progress "Fast updating #{target}.scss"
 
-            target, name, type_id = resolved
-            UI.progress "Fast updating #{target}.scss"
-
-            @uploader.upload_theme_field(
-              target: target,
-              name: name,
-              value: File.read(modified[0]),
-              type_id: type_id
-            )
-          else
-            count = modified.length + added.length + removed.length
-            if count > 1
-              UI.progress "Detected changes in #{count} files, uploading theme"
+              @uploader.upload_theme_field(
+                target: target,
+                name: name,
+                value: File.read(modified[0]),
+                type_id: type_id,
+              )
             else
-              filename = modified[0] || added[0] || removed[0]
-              UI.progress "Detected changes in #{filename.gsub(@dir, '')}, uploading theme"
+              count = modified.length + added.length + removed.length
+              if count > 1
+                UI.progress "Detected changes in #{count} files, uploading theme"
+              else
+                filename = modified[0] || added[0] || removed[0]
+                UI.progress "Detected changes in #{filename.gsub(@dir, "")}, uploading theme"
+              end
+              @uploader.upload_full_theme
             end
-            @uploader.upload_full_theme
+            UI.success "Done! Watching for changes..."
+          rescue DiscourseTheme::ThemeError => e
+            UI.error "#{e.message}"
+            UI.progress "Watching for changes..."
           end
-          UI.success "Done! Watching for changes..."
-        rescue DiscourseTheme::ThemeError => e
-          UI.error "#{e.message}"
-          UI.progress "Watching for changes..."
         end
-      end
 
       listener.start
       sleep unless self.class.return_immediately?
@@ -60,10 +58,10 @@ module DiscourseTheme
 
       target, file = name.split("/")
 
-      if ["common", "desktop", "mobile"].include?(target)
+      if %w[common desktop mobile].include?(target)
         if file == "#{target}.scss"
           # a CSS file
-          return [target, "scss", 1]
+          return target, "scss", 1
         end
       end
 

--- a/test/test_config.rb
+++ b/test/test_config.rb
@@ -46,7 +46,6 @@ class TestConfig < Minitest::Test
     captured = capture_stderr { DiscourseTheme::Config.new filename }
 
     assert(captured.include? "ERROR")
-
   ensure
     File.unlink filename
   end
@@ -61,7 +60,6 @@ class TestConfig < Minitest::Test
     config = DiscourseTheme::Config.new filename
     assert_nil(config["/test"].url)
     assert_equal("abc", config["/test"].api_key)
-
   ensure
     File.unlink(filename)
   end
@@ -78,7 +76,6 @@ class TestConfig < Minitest::Test
 
     assert_equal("bla", settings.api_key)
     assert_equal("http://a.com", settings.url)
-
   ensure
     File.unlink(filename)
   end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -3,4 +3,4 @@ $LOAD_PATH.unshift File.expand_path("../../lib", __FILE__)
 require "discourse_theme"
 
 require "minitest/autorun"
-require 'webmock/minitest'
+require "webmock/minitest"


### PR DESCRIPTION
Why this change?

`discourse/discourse` has already adopted syntax_tree for formatting for a long while and we should do the same with gems maintained by Discourse.