### PR TITLE
FIX: Change `rspec` headless option to headful

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.0] - 2023-10-09
+
+### Fixed
+
+- Change `--headless` option for the rspec command to `--headful` which is the correct name.
+
 ## [0.9.1] - 2023-10-06
 
 ### Fixed

--- a/lib/discourse_theme/cli.rb
+++ b/lib/discourse_theme/cli.rb
@@ -23,7 +23,7 @@ module DiscourseTheme
         upload DIR            - Uploads the theme from the specified directory to Discourse.
         watch DIR             - Watches the theme in the specified directory and synchronizes any changes with Discourse.
         rspec DIR [OPTIONS]   - Runs the RSpec tests in the specified directory. The tests can be run using a local Discourse repository or a Docker container.
-          --headless          - Runs the RSpec system type tests in headless mode. Applies to both modes.
+          --headful           - Runs the RSpec system type tests in headful mode. Applies to both modes.
 
           If specified directory has been configured to run in a Docker container, the additional options are supported.
           --rebuild           - Forces a rebuilds of Docker container.

--- a/lib/discourse_theme/cli_commands/rspec.rb
+++ b/lib/discourse_theme/cli_commands/rspec.rb
@@ -7,7 +7,7 @@ module DiscourseTheme
     class Rspec
       DISCOURSE_TEST_DOCKER_CONTAINER_NAME_PREFIX = "discourse_theme_test"
       DISCOURSE_THEME_TEST_TMP_DIR = "/tmp/.discourse_theme_test"
-      SELENIUM_HEADLESS_ENV = "SELENIUM_HEADLESS=0"
+      SELENIUM_HEADFUL_ENV = "SELENIUM_HEADLESS=0"
 
       class << self
         def discourse_test_docker_container_name
@@ -33,7 +33,7 @@ module DiscourseTheme
 
           configure_local_directory(settings)
 
-          headless = !!args.delete("--headless")
+          headless = !args.delete("--headful")
 
           if settings.local_discourse_directory.empty?
             run_tests_with_docker(
@@ -88,7 +88,7 @@ module DiscourseTheme
 
           Kernel.exec(
             ENV,
-            "cd #{local_directory} && #{headless ? SELENIUM_HEADLESS_ENV : ""} bundle exec rspec #{spec_path}",
+            "cd #{local_directory} && #{headless ? "" : SELENIUM_HEADFUL_ENV} bundle exec rspec #{spec_path}",
           )
         end
 
@@ -171,7 +171,7 @@ module DiscourseTheme
 
           rspec_envs = []
 
-          if headless
+          if !headless
             container_ip =
               execute(
                 command:
@@ -181,7 +181,7 @@ module DiscourseTheme
             service =
               start_chromedriver(allowed_origin: "host.docker.internal", allowed_ip: container_ip)
 
-            rspec_envs.push(SELENIUM_HEADLESS_ENV)
+            rspec_envs.push(SELENIUM_HEADFUL_ENV)
             rspec_envs.push("CAPYBARA_SERVER_HOST=0.0.0.0")
             rspec_envs.push(
               "CAPYBARA_REMOTE_DRIVER_URL=http://host.docker.internal:#{service.uri.port}",

--- a/lib/discourse_theme/version.rb
+++ b/lib/discourse_theme/version.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 module DiscourseTheme
-  VERSION = "0.9.1"
+  VERSION = "1.0.0"
 end

--- a/test/test_cli.rb
+++ b/test/test_cli.rb
@@ -295,10 +295,10 @@ class TestCli < Minitest::Test
     end
   end
 
-  def mock_rspec_local_discourse_commands(dir, spec_dir, rspec_path: "/spec", headless: false)
+  def mock_rspec_local_discourse_commands(dir, spec_dir, rspec_path: "/spec", headless: true)
     Kernel.expects(:exec).with(
       anything,
-      "cd #{dir} && #{headless ? DiscourseTheme::CliCommands::Rspec::SELENIUM_HEADLESS_ENV : ""} bundle exec rspec #{File.join(spec_dir, rspec_path)}",
+      "cd #{dir} && #{headless ? "" : DiscourseTheme::CliCommands::Rspec::SELENIUM_HEADFUL_ENV} bundle exec rspec #{File.join(spec_dir, rspec_path)}",
     )
   end
 
@@ -307,7 +307,7 @@ class TestCli < Minitest::Test
     setup_commands:,
     rspec_path: "/spec",
     container_state: nil,
-    headless: false
+    headless: true
   )
     DiscourseTheme::CliCommands::Rspec
       .expects(:execute)
@@ -376,7 +376,7 @@ class TestCli < Minitest::Test
       )
     end
 
-    if headless
+    if !headless
       fake_ip = "123.456.789"
 
       DiscourseTheme::CliCommands::Rspec
@@ -449,12 +449,12 @@ class TestCli < Minitest::Test
     assert_equal(settings(@spec_dir).local_discourse_directory, @discourse_dir)
   end
 
-  def test_rspec_using_local_discourse_repository_with_headless_option
-    args = ["rspec", @spec_dir, "--headless"]
+  def test_rspec_using_local_discourse_repository_with_headful_option
+    args = ["rspec", @spec_dir, "--headful"]
 
     cli = DiscourseTheme::Cli.new
 
-    mock_rspec_local_discourse_commands(@discourse_dir, @spec_dir, headless: true)
+    mock_rspec_local_discourse_commands(@discourse_dir, @spec_dir, headless: false)
     run_cli_rspec_with_local_discourse_repository(cli, args, @discourse_dir)
   end
 
@@ -509,11 +509,11 @@ class TestCli < Minitest::Test
     run_cli_rspec_with_docker(cli, args)
   end
 
-  def test_rspec_using_docker_with_headless_option
-    args = ["rspec", @spec_dir, "--headless"]
+  def test_rspec_using_docker_with_headful_option
+    args = ["rspec", @spec_dir, "--headful"]
 
     cli = DiscourseTheme::Cli.new
-    mock_rspec_docker_commands(verbose: false, setup_commands: true, headless: true)
+    mock_rspec_docker_commands(verbose: false, setup_commands: true, headless: false)
 
     run_cli_rspec_with_docker(cli, args)
   end


### PR DESCRIPTION
Why this change?

By default Discourse Rails system tests are ran in the headless mode. The option here was supposed to disable the headless mode so `--headless` is not the right naming for it.