### PR TITLE
FIX: RSpec path not being preserved when running rspec command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.1] - 2023-10-19
+
+## Fixed
+
+- Spec path was not preserved when running rspec against a local Discourse repository.
+
 ## [1.0.0] - 2023-10-09
 
 ### Fixed

--- a/lib/discourse_theme/cli_commands/rspec.rb
+++ b/lib/discourse_theme/cli_commands/rspec.rb
@@ -47,7 +47,7 @@ module DiscourseTheme
           else
             run_tests_locally(
               settings.local_discourse_directory,
-              spec_directory,
+              File.join(dir, spec_path),
               headless: headless,
             )
           end

--- a/lib/discourse_theme/version.rb
+++ b/lib/discourse_theme/version.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 module DiscourseTheme
-  VERSION = "1.0.0"
+  VERSION = "1.0.1"
 end

--- a/test/test_cli.rb
+++ b/test/test_cli.rb
@@ -443,7 +443,39 @@ class TestCli < Minitest::Test
 
     cli = DiscourseTheme::Cli.new
 
-    mock_rspec_local_discourse_commands(@discourse_dir, @spec_dir)
+    mock_rspec_local_discourse_commands(@discourse_dir, @spec_dir, rspec_path: "/spec/system")
+    run_cli_rspec_with_local_discourse_repository(cli, args, @discourse_dir)
+
+    assert_equal(settings(@spec_dir).local_discourse_directory, @discourse_dir)
+  end
+
+  def test_rspec_using_local_discourse_repository_dir_path_to_custom_rspec_file
+    args = ["rspec", File.join(@spec_dir, "/spec/system/some_spec.rb")]
+
+    cli = DiscourseTheme::Cli.new
+
+    mock_rspec_local_discourse_commands(
+      @discourse_dir,
+      @spec_dir,
+      rspec_path: "/spec/system/some_spec.rb",
+    )
+
+    run_cli_rspec_with_local_discourse_repository(cli, args, @discourse_dir)
+
+    assert_equal(settings(@spec_dir).local_discourse_directory, @discourse_dir)
+  end
+
+  def test_rspec_using_local_discourse_repository_dir_path_to_custom_rspec_file_with_line_number
+    args = ["rspec", File.join(@spec_dir, "/spec/system/some_spec.rb:44")]
+
+    cli = DiscourseTheme::Cli.new
+
+    mock_rspec_local_discourse_commands(
+      @discourse_dir,
+      @spec_dir,
+      rspec_path: "/spec/system/some_spec.rb:44",
+    )
+
     run_cli_rspec_with_local_discourse_repository(cli, args, @discourse_dir)
 
     assert_equal(settings(@spec_dir).local_discourse_directory, @discourse_dir)


### PR DESCRIPTION
This fixes a regression when running the `rspec` command against a local Discourse repository. Running `discourse_theme rspec /path/to/theme/spec/system/some_spec.rb` ended up running all the tests in `/path/to/theme/spec` instead when it should only run the tests in the `/path/to/theme/spec/system/some_spec.rb` spec file.