### PR TITLE
DEV: Require non-spec files when running specs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.2] - 2023-11-07
+
+### Added
+
+- Allow helper files to be required with the `rspec` command.
+  All non `spec.rb` files in the `/spec` directory will be required.
+
 ## [1.0.1] - 2023-10-19
 
 ## Fixed

--- a/lib/discourse_theme/cli_commands/rspec.rb
+++ b/lib/discourse_theme/cli_commands/rspec.rb
@@ -90,7 +90,7 @@ module DiscourseTheme
             "Running RSpec tests using local Discourse repository located at '#{local_directory}'...",
           )
 
-          spec_requires = require_paths.map { |path| "-r #{path}" }.join(" ")
+          spec_requires = require_paths.map { |path| "--require #{path}" }.join(" ")
 
           Kernel.exec(
             ENV,
@@ -205,7 +205,7 @@ module DiscourseTheme
             rspec_spec_path = File.join("/tmp", theme_directory_name, spec_path)
             rspec_spec_requires =
               require_paths
-                .map { |path| "-r #{File.join("/tmp", theme_directory_name, path)}" }
+                .map { |path| "--require #{File.join("/tmp", theme_directory_name, path)}" }
                 .join(" ")
             execute(
               command:

--- a/lib/discourse_theme/cli_commands/rspec.rb
+++ b/lib/discourse_theme/cli_commands/rspec.rb
@@ -35,8 +35,7 @@ module DiscourseTheme
 
           headless = !args.delete("--headful")
 
-          required_paths =
-            list_files_in_directory("#{spec_directory}/system/page_objects", spec_directory)
+          required_paths = list_non_spec_files_in_directory(spec_directory)
 
           if settings.local_discourse_directory.empty?
             run_tests_with_docker(
@@ -254,25 +253,11 @@ module DiscourseTheme
           service.launch
         end
 
-        # Returns a list of files recursively from `directory`, and prepends `base_directory` to each file.
-        #
-        # /spec/helpers/foo.rb
-        # /spec/helpers/bar.rb
-        # /spec/baz.rb
-        #
-        # list_files_in_directory("/spec/helpers", "/spec")
-        # will return ["spec/helpers/foo.rb", "spec/helpers/bar.rb"]
-        #
-        # list_files_in_directory("/spec/helpers")
-        # will return ["helpers/foo.rb", "helpers/bar.rb"]
-        def list_files_in_directory(directory, base_directory = nil)
-          base_directory ||= directory
+        def list_non_spec_files_in_directory(directory)
           Dir
             .glob(File.join(directory, "**", "*"))
-            .select { |file| File.file?(file) }
-            .map do |file|
-              File.join(File.basename(base_directory), file.sub("#{base_directory}/", ""))
-            end
+            .select { |file| File.file?(file) && !file.end_with?("spec.rb") }
+            .map { |file| File.join(File.basename(directory), file.sub("#{directory}/", "")) }
         end
       end
     end

--- a/test/test_cli.rb
+++ b/test/test_cli.rb
@@ -295,10 +295,16 @@ class TestCli < Minitest::Test
     end
   end
 
-  def mock_rspec_local_discourse_commands(dir, spec_dir, rspec_path: "/spec", headless: true)
+  def mock_rspec_local_discourse_commands(
+    dir,
+    spec_dir,
+    rspec_path: "/spec",
+    requires: "",
+    headless: true
+  )
     Kernel.expects(:exec).with(
       anything,
-      "cd #{dir} && #{headless ? "" : DiscourseTheme::CliCommands::Rspec::SELENIUM_HEADFUL_ENV} bundle exec rspec #{File.join(spec_dir, rspec_path)}",
+      "cd #{dir} && #{headless ? "" : DiscourseTheme::CliCommands::Rspec::SELENIUM_HEADFUL_ENV} bundle exec rspec #{requires} #{File.join(spec_dir, rspec_path)}",
     )
   end
 


### PR DESCRIPTION
A theme author is currently unable to add page objects. This change allows non `spec.rb` files in the `spec` folder to be required when running the `rspec` command locally and in docker.

I considered some other way to allow the files to be required, e.g. another helper file, but because we're running rspec in an interesting way both locally (using a local instance of core) and via docker (copying required files, then running rspec), this seems to be the least annoying way to do so without a core change.