### PR TITLE
FEATURE: Add upload theme migrations prompt to `watch` commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.0] - 2024-01-10
+
+### Added
+
+- Add upload theme migrations prompt to `watch` command for `discourse_theme` CLI (#38)
+
 ## [1.0.2] - 2023-12-08
 
 ### Fixed

--- a/lib/discourse_theme/ui.rb
+++ b/lib/discourse_theme/ui.rb
@@ -28,6 +28,10 @@ module DiscourseTheme
       puts @@pastel.red("✘ #{message}")
     end
 
+    def self.warn(message)
+      puts @@pastel.yellow("⚠ #{message}")
+    end
+
     def self.success(message)
       puts @@pastel.green("✔ #{message}")
     end

--- a/lib/discourse_theme/uploader.rb
+++ b/lib/discourse_theme/uploader.rb
@@ -1,6 +1,20 @@
 # frozen_string_literal: true
 module DiscourseTheme
   class Uploader
+    def self.upload_full_theme_callbacks
+      @upload_callbacks ||= []
+    end
+
+    # Used in the test environment to register a callback that is called with the directory of the theme being uploaded.
+    def self.register_upload_full_theme_callback(&block)
+      self.upload_full_theme_callbacks << block
+    end
+
+    # Used in the test environment to clear the registered callbacks.
+    def self.reset_upload_full_theme_callbacks
+      self.upload_full_theme_callbacks.clear
+    end
+
     def initialize(dir:, client:, theme_id: nil, components: nil)
       @dir = dir
       @client = client
@@ -53,9 +67,24 @@ module DiscourseTheme
       UI.error "(end of errors)" if diagnose_errors(json) != 0
     end
 
-    def upload_full_theme
+    def upload_full_theme(ignore_files: [])
       filename = "#{Pathname.new(Dir.tmpdir).realpath}/bundle_#{SecureRandom.hex}.tar.gz"
-      compress_dir(filename, @dir)
+      temp_dir = nil
+
+      theme_dir =
+        if !ignore_files.empty?
+          temp_dir = Dir.mktmpdir
+          FileUtils.copy_entry(@dir, temp_dir)
+          dir_pathname = Pathname.new(@dir)
+          ignore_files.each { |file| FileUtils.rm_f(File.join(temp_dir, file)) }
+          temp_dir
+        else
+          @dir
+        end
+
+      self.class.upload_full_theme_callbacks.each { |cb| cb.call(theme_dir) }
+
+      compress_dir(filename, theme_dir)
 
       File.open(filename) do |tgz|
         response = @client.upload_full_theme(tgz, theme_id: @theme_id, components: @components)
@@ -66,7 +95,8 @@ module DiscourseTheme
         @theme_id
       end
     ensure
-      FileUtils.rm_f filename
+      FileUtils.rm_rf(temp_dir) if temp_dir
+      FileUtils.rm_f(filename)
     end
   end
 end

--- a/lib/discourse_theme/version.rb
+++ b/lib/discourse_theme/version.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 module DiscourseTheme
-  VERSION = "1.0.2"
+  VERSION = "1.1.0"
 end


### PR DESCRIPTION
Why this change?

Prior to this change, running `discourse_theme watch` on a theme directory will upload theme migration files. This means that the theme migration is uploaded and ran on the server even if the author has not finished writing the migration. To avoid this problem, `discourse_theme watch` will now prompt for the user as to whether they would like to upload and run the pending migrations in the theme. Example output is below:

```
» Using http://localhost:4200 from /home/tgxworld/.discourse_theme
» Using api key from /home/tgxworld/.discourse_theme
? How would you like to sync this theme? Sync with existing theme: 'DiscoTOC' (id:38)
» Uploading theme from /home/tgxworld/work/DiscoTOC
? Would you like to upload and run the following pending theme migration(s): /home/tgxworld/work/DiscoTOC/migrations/settings/0003-rename-settings.js

‣ Yes
  No
```