### PR TITLE
FIX: Various watch CLI command fixes. 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Fixed
+
+- `DiscourseTheme::Watcher` was incorrectly ignoring any files with `migrations` in the pathname. (#39)
+- `DiscourseTheme::Watcher` was incorrectly uploading migration files when any file changes have been detected. (#39)
+
 ## [1.1.0] - 2024-01-10
 
 ### Added

--- a/lib/discourse_theme/uploader.rb
+++ b/lib/discourse_theme/uploader.rb
@@ -67,16 +67,16 @@ module DiscourseTheme
       UI.error "(end of errors)" if diagnose_errors(json) != 0
     end
 
-    def upload_full_theme(ignore_files: [])
+    def upload_full_theme(ignore_files: [], ignore_directories: [])
       filename = "#{Pathname.new(Dir.tmpdir).realpath}/bundle_#{SecureRandom.hex}.tar.gz"
       temp_dir = nil
 
       theme_dir =
-        if !ignore_files.empty?
+        if !ignore_files.empty? || !ignore_directories.empty?
           temp_dir = Dir.mktmpdir
           FileUtils.copy_entry(@dir, temp_dir)
-          dir_pathname = Pathname.new(@dir)
           ignore_files.each { |file| FileUtils.rm_f(File.join(temp_dir, file)) }
+          ignore_directories.each { |directory| FileUtils.rm_rf(File.join(temp_dir, directory)) }
           temp_dir
         else
           @dir

--- a/lib/discourse_theme/watcher.rb
+++ b/lib/discourse_theme/watcher.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 module DiscourseTheme
   class Watcher
-    LISTEN_IGNORE_PATTERNS = [%r{migrations/.+/.+\.js}]
-
     def self.return_immediately!
       @return_immediately = true
     end
@@ -35,7 +33,7 @@ module DiscourseTheme
 
     def watch
       listener =
-        Listen.to(@dir, ignore: LISTEN_IGNORE_PATTERNS) do |modified, added, removed|
+        Listen.to(@dir, ignore: /\Amigrations/) do |modified, added, removed|
           yield(modified, added, removed) if block_given?
 
           begin
@@ -60,7 +58,7 @@ module DiscourseTheme
                 UI.progress "Detected changes in #{filename.gsub(@dir, "")}, uploading theme"
               end
 
-              @uploader.upload_full_theme
+              @uploader.upload_full_theme(ignore_directories: ["migrations"])
             end
             UI.success "Done! Watching for changes..."
           rescue DiscourseTheme::ThemeError => e


### PR DESCRIPTION
This commit is a follow-up to https://github.com/discourse/discourse_theme/commit/7e2b90f5e13e8e30b3e1171fbf5183b61793c6f1

What was fixed in this commit?

1. Fix `DiscourseTheme::Watcher` which was incorrectly ignoring any file
   with `migrations` in each path. This is incorrect as theme migration
   tests files may contain `migrations` in its path.

2. Fix `DiscourseTheme::Watcher` uploading theme migrations when a change has
   been detected. We do not want theme migrations to be automatically
   uploaded so this commit fixes that.