### PR TITLE
FEATURE: `watch` command prompts user if theme migrations should run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
-### Fixed
+### Added
 
-- `DiscourseTheme::Watcher` was incorrectly ignoring any files with `migrations` in the pathname. (#39)
-- `DiscourseTheme::Watcher` was incorrectly uploading migration files when any file changes have been detected. (#39)
+- `watch` command for `discourse_theme` will prompt user if pending theme migrations should be run (#40)
+
+### Removed
+
+- Remove upload theme migrations prompt to `watch` command for `discourse_theme` CLI previously added in #38. Theme migrations
+  files are always uploaded going forward.
 
 ## [1.1.0] - 2024-01-10
 

--- a/lib/discourse_theme/client.rb
+++ b/lib/discourse_theme/client.rb
@@ -84,7 +84,7 @@ module DiscourseTheme
       request(put)
     end
 
-    def upload_full_theme(tgz, theme_id:, components:)
+    def upload_full_theme(tgz, theme_id:, components:, skip_migrations: false)
       endpoint =
         root +
           (
@@ -95,13 +95,15 @@ module DiscourseTheme
             end
           )
 
-      post =
-        Net::HTTP::Post::Multipart.new(
-          endpoint,
-          "theme_id" => theme_id,
-          "components" => components,
-          "bundle" => UploadIO.new(tgz, "application/tar+gzip", "bundle.tar.gz"),
-        )
+      params = {
+        "theme_id" => theme_id,
+        "components" => components,
+        "bundle" => UploadIO.new(tgz, "application/tar+gzip", "bundle.tar.gz"),
+      }
+
+      params["skip_migrations"] = true if skip_migrations
+
+      post = Net::HTTP::Post::Multipart.new(endpoint, params)
       request(post)
     end
 


### PR DESCRIPTION
This commit is a partial revert of
7e2b90f5e13e8e30b3e1171fbf5183b61793c6f1 and
8e3b6c771130d5dee6297a32223fbf782ac68acc.

Previously, our strategy was to not upload theme migration files if the user was not ready to run the theme migration files. However, this is a problem because not uploading the theme migration files mean that we are unable to write and run QUnit tests for the migrations.

Therefore, this commit changes our strategy to always upload theme migrations file like before but adds the `skip_migrations` field to the body of the upload theme request to indicate to the server that it should not run theme migrations.