### PR TITLE
FEATURE: Suggest the root URL of the local site when running `watch` command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Suggest the root URL of the local site when running `watch` command
+
+## [2.1.1] - 2024-03-25
+
+### Added
+
 - `--version` to CLI (#46)
 
 ## [2.1.0] - 2024-02-28

--- a/lib/discourse_theme/client.rb
+++ b/lib/discourse_theme/client.rb
@@ -177,7 +177,10 @@ module DiscourseTheme
       end
 
       if !url || @reset
-        url = normalize_url(UI.ask("What is the root URL of your Discourse site?", default: url))
+        url =
+          normalize_url(
+            UI.ask("What is the root URL of your Discourse site?", default: settings.possible_url),
+          )
         url = "http://#{url}" unless url =~ %r{^https?://}
 
         # maybe this is an HTTPS redirect

--- a/lib/discourse_theme/config.rb
+++ b/lib/discourse_theme/config.rb
@@ -22,6 +22,13 @@ class DiscourseTheme::Config
       set("url", val)
     end
 
+    def possible_url
+      return safe_config["url"] if safe_config["url"]
+
+      first_config = @config.raw_config.values.find { |config| config["url"] }
+      first_config["url"] if first_config
+    end
+
     def theme_id
       safe_config["theme_id"].to_i
     end

--- a/lib/discourse_theme/version.rb
+++ b/lib/discourse_theme/version.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 module DiscourseTheme
-  VERSION = "2.1.1"
+  VERSION = "2.1.2"
 end


### PR DESCRIPTION
It takes the first URL in the config.

Before:

```sh
❯ discourse_theme watch .
? What is the root URL of your Discourse site?
```

After:

```sh
❯ ./bin/discourse_theme watch .
? What is the root URL of your Discourse site? (http://localhost:4200)
```
