### PR TITLE
DEV: add pnpm compat in preparation of new changes to theme-skeleton

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,9 @@ jobs:
           git config --global user.email "ci@ci.invalid"
           git config --global user.name "Discourse CI"
 
+      - name: Install pnpm
+        run: npm install -g pnpm
+
       - name: Setup ruby
         uses: ruby/setup-ruby@v1
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Made `new` command compatible with the replacement of `yarn` with `pnpm` as a package manager, and will prompt users to install `pnpm` if not installed already.
 
-## [2.1.2] - 2024-03-25
+## [2.1.2] - 2024-04-16
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [2.1.1] - 2024-03-25
+## [2.1.3] - 2024-10-09
+
+### Added
+
+- Made `new` command compatible with the replacement of `yarn` with `pnpm` as a package manager, and will prompt users to install `pnpm` if not installed already.
+
+## [2.1.2] - 2024-03-25
 
 ### Added
 

--- a/discourse_theme.gemspec
+++ b/discourse_theme.gemspec
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 lib = File.expand_path("../lib", __FILE__)
-$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
+$LOAD_PATH.unshift(lib) if !$LOAD_PATH.include?(lib)
 require "discourse_theme/version"
 
 Gem::Specification.new do |spec|
@@ -36,7 +36,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "guard"
   spec.add_development_dependency "guard-minitest"
   spec.add_development_dependency "webmock"
-  spec.add_development_dependency "rubocop-discourse", "~> 3.6.0"
+  spec.add_development_dependency "rubocop-discourse", "~> 3.8.1"
   spec.add_development_dependency "m"
   spec.add_development_dependency "syntax_tree"
   spec.add_development_dependency "mocha"

--- a/lib/discourse_theme/cli.rb
+++ b/lib/discourse_theme/cli.rb
@@ -61,6 +61,7 @@ module DiscourseTheme
         end
         raise DiscourseTheme::ThemeError.new "git is not installed" if !command?("git")
         raise DiscourseTheme::ThemeError.new "yarn is not installed" if !command?("yarn")
+        raise DiscourseTheme::ThemeError.new "pnpm is not installed" if !command?("pnpm")
 
         DiscourseTheme::Scaffold.generate(dir, name: args[1])
         watch_theme?(args)

--- a/lib/discourse_theme/scaffold.rb
+++ b/lib/discourse_theme/scaffold.rb
@@ -65,7 +65,14 @@ module DiscourseTheme
                exception: true
 
         UI.info "Installing dependencies"
-        system "yarn", exception: true
+        if File.exist?("yarn.lock")
+          system "yarn", exception: true
+        elsif File.exist?("pnpm-lock.yaml")
+          system "pnpm", "install", exception: true
+        else
+          UI.warn "No lock file found. Defaulting to pnpm."
+          system "pnpm", "install", exception: true
+        end
       end
 
       puts "✅ Done!"

--- a/lib/discourse_theme/version.rb
+++ b/lib/discourse_theme/version.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 module DiscourseTheme
-  VERSION = "2.1.2"
+  VERSION = "2.1.3"
 end

--- a/test/fixtures/skeleton-lite/package.json
+++ b/test/fixtures/skeleton-lite/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "skeleton-lite",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "MIT"
+}


### PR DESCRIPTION
We are preparing to switch to `pnpm` for all themes/plugins now that the change has landed in core. This change makes the discourse_theme CLI compatible with that change to theme-skeleton. We will remove all usage of yarn in an upcoming minor version bump once pnpm is fully rolled out.

For more context: https://meta.discourse.org/t/discourse-core-is-switching-to-pnpm-for-js-package-management/324521
