### PR TITLE
Ignore node_modules in file watcher

### DIFF
--- a/lib/discourse_theme/version.rb
+++ b/lib/discourse_theme/version.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 module DiscourseTheme
-  VERSION = "2.1.3"
+  VERSION = "2.1.4"
 end

--- a/lib/discourse_theme/watcher.rb
+++ b/lib/discourse_theme/watcher.rb
@@ -16,7 +16,7 @@ module DiscourseTheme
 
     def watch
       listener =
-        Listen.to(@dir) do |modified, added, removed|
+        Listen.to(@dir, ignore: %r{^node_modules/}) do |modified, added, removed|
           begin
             if modified.length == 1 && added.length == 0 && removed.length == 0 &&
                  (resolved = resolve_file(modified[0]))


### PR DESCRIPTION
This silences the `Listen` gem's warning "ERROR: directory is already being watched!", caused by the symlinks which pnpm uses in node_modules.