### PR TITLE
Reduce number of required tools

### DIFF
--- a/discourse_theme.gemspec
+++ b/discourse_theme.gemspec
@@ -7,8 +7,8 @@ require "discourse_theme/version"
 Gem::Specification.new do |spec|
   spec.name = "discourse_theme"
   spec.version = DiscourseTheme::VERSION
-  spec.authors = ["Sam Saffron"]
-  spec.email = ["sam.saffron@gmail.com"]
+  spec.authors = ["Discourse Team"]
+  spec.email = ["team@discourse.org"]
 
   spec.summary = "CLI helper for creating Discourse themes"
   spec.description = "CLI helper for creating Discourse themes"

--- a/lib/discourse_theme/cli.rb
+++ b/lib/discourse_theme/cli.rb
@@ -13,6 +13,10 @@ module DiscourseTheme
       @@cli_settings_filename = filename
     end
 
+    def self.command?(cmd)
+      system "which", cmd, out: File::NULL, err: File::NULL
+    end
+
     def usage
       puts <<~USAGE
       Usage: discourse_theme COMMAND [DIR] [OPTIONS]
@@ -59,9 +63,7 @@ module DiscourseTheme
         if Dir.exist?(dir) && !Dir.empty?(dir)
           raise DiscourseTheme::ThemeError.new "'#{dir}' is not empty"
         end
-        raise DiscourseTheme::ThemeError.new "git is not installed" if !command?("git")
-        raise DiscourseTheme::ThemeError.new "yarn is not installed" if !command?("yarn")
-        raise DiscourseTheme::ThemeError.new "pnpm is not installed" if !command?("pnpm")
+        raise DiscourseTheme::ThemeError.new "git is not installed" if !Cli.command?("git")
 
         DiscourseTheme::Scaffold.generate(dir, name: args[1])
         watch_theme?(args)
@@ -247,20 +249,6 @@ module DiscourseTheme
       else
         false
       end
-    end
-
-    def command?(cmd)
-      exts = ENV["PATHEXT"] ? ENV["PATHEXT"].split(";") : [""]
-      ENV["PATH"]
-        .split(File::PATH_SEPARATOR)
-        .each do |path|
-          exts.each do |ext|
-            exe = File.join(path, "#{cmd}#{ext}")
-            return true if File.executable?(exe) && !File.directory?(exe)
-          end
-        end
-
-      false
     end
 
     def watch_theme?(args)

--- a/lib/discourse_theme/scaffold.rb
+++ b/lib/discourse_theme/scaffold.rb
@@ -64,19 +64,16 @@ module DiscourseTheme
                "--quiet",
                exception: true
 
-        UI.info "Installing dependencies"
-        if File.exist?("yarn.lock")
-          system "yarn", exception: true
-        elsif File.exist?("pnpm-lock.yaml")
+        if Cli.command?("pnpm")
+          UI.info "Installing dependencies"
           system "pnpm", "install", exception: true
         else
-          UI.warn "No lock file found. Defaulting to pnpm."
-          system "pnpm", "install", exception: true
+          UI.warn "`pnpm` is not installed, skipping installation of linting dependencies"
         end
       end
 
       puts "✅ Done!"
-      puts "See https://meta.discourse.org/t/how-to-develop-custom-themes/60848 for more information!"
+      puts "See https://meta.discourse.org/t/93648 for more information!"
     end
 
     private

--- a/lib/discourse_theme/version.rb
+++ b/lib/discourse_theme/version.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 module DiscourseTheme
-  VERSION = "2.1.4"
+  VERSION = "2.1.5"
 end


### PR DESCRIPTION
- Remove `yarn` dependency. This is no longer used by the theme skeleton

- Make `pnpm` dependency optional. This is only used for linting, so it's better to allow `discourse_theme new` to work without it, and then people can set up pnpm/linting as a separate task

Also simplifies the check for external tools, bumps the version, and updates the gem author info