### PR TITLE
Generate gjs initializer during `discourse_theme new`

### DIFF
--- a/lib/discourse_theme/scaffold.rb
+++ b/lib/discourse_theme/scaffold.rb
@@ -39,10 +39,14 @@ module DiscourseTheme
         File.write("README.md", readme)
 
         encoded_name = name.downcase.gsub(/[^a-zA-Z0-9_-]+/, "-")
-        FileUtils.mv(
-          "javascripts/discourse/api-initializers/todo.js",
-          "javascripts/discourse/api-initializers/#{encoded_name}.js",
-        )
+
+        todo_initializer = "javascripts/discourse/api-initializers/todo.js"
+        if File.exist?(todo_initializer)
+          FileUtils.mv(
+            "javascripts/discourse/api-initializers/todo.js",
+            "javascripts/discourse/api-initializers/#{encoded_name}.gjs",
+          )
+        end
 
         i18n = YAML.safe_load(File.read("locales/en.yml"))
         i18n["en"]["theme_metadata"]["description"] = description

--- a/lib/discourse_theme/version.rb
+++ b/lib/discourse_theme/version.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 module DiscourseTheme
-  VERSION = "2.1.5"
+  VERSION = "2.1.6"
 end

--- a/test/test_cli.rb
+++ b/test/test_cli.rb
@@ -375,7 +375,7 @@ class TestCli < Minitest::Test
     suppress_output { Dir.chdir(@dir) { DiscourseTheme::Cli.new.run(%w[new foo]) } }
 
     Dir.chdir(@dir + "/foo") do
-      assert(File.exist?("javascripts/discourse/api-initializers/my-theme.js"))
+      assert(File.exist?("javascripts/discourse/api-initializers/my-theme.gjs"))
 
       assert_equal(
         "A magical theme",


### PR DESCRIPTION
Also adds an existence check, to make it easier to rename the todo.js file in future